### PR TITLE
Re-enable temp sensor during resume

### DIFF
--- a/spd5118.c
+++ b/spd5118.c
@@ -472,6 +472,9 @@ static int spd5118_resume(struct device *dev)
 	struct regmap *regmap = dev_get_drvdata(dev);
 
 	regcache_cache_only(regmap, false);
+
+	regmap_update_bits(regmap, SPD5118_REG_TEMP_CONFIG, SPD5118_TS_DISABLE, 0);
+
 	return regcache_sync(regmap);
 }
 


### PR DESCRIPTION
Hi Guenter,

I saw on the lkml that you had trouble testing suspend support. I am to be able to suspend, but it seems the temperature sensors never get re-enabled after resume, and just report `0` instead.

This little PR fixes that, but I wouldn't mind knowing if there's a better way.

Thanks,
Steve